### PR TITLE
Fixed crash when opening settings on iPad

### DIFF
--- a/Frameless/ViewController.swift
+++ b/Frameless/ViewController.swift
@@ -238,7 +238,12 @@ class ViewController: UIViewController, UISearchBarDelegate, FramelessSearchBarD
         var settingsController: SettingsViewController = storyboard?.instantiateViewControllerWithIdentifier("settingsController") as! SettingsViewController
         settingsController.delegate = self
         settingsController.modalPresentationStyle = .FormSheet
-        self.presentViewController(settingsController, animated: true, completion: nil)
+        
+        // Animated form sheet presentation was crashing on regular size class (all iPads, and iPhone 6+ landscape).
+        // Disabling the animation until the root cause of that crash is found.
+        let shouldAnimateSettingsPresentation: Bool = self.traitCollection.horizontalSizeClass != .Regular
+        
+        self.presentViewController(settingsController, animated: shouldAnimateSettingsPresentation, completion: nil)
     }
     
     


### PR DESCRIPTION
## Observed behavior

Tapping the settings button is crashing in all cases where the horizontal size class is Regular (all iPads, and iPhone 6+ in landscape).

## Expected behavior

Obviously, shouldn’t crash.

## Notes

Maybe a nicer fix can be done that preserves the animation, but I couldn’t immediately find out what was going on. Stack trace was all about UIKit internals and feels like this kind of presentation is just pooping on itself in this situation. So, disabled the presentation animation until the root cause of the crash is found, so that at least the app keeps working and you can change settings in these cases.